### PR TITLE
Some corrections for Mycelium Android

### DIFF
--- a/matrix.json
+++ b/matrix.json
@@ -31,19 +31,35 @@
                     },
                     {
                         "type": "crypto",
-                        "ticker": "BCH"
+                        "ticker": "BTCV"
+                    },
+                    {
+                        "type": "crypto",
+                        "ticker": "USDT"
                     },
                     {
                         "type": "crypto",
                         "ticker": "ETH"
                     },
                     {
-                        "type": "crypto",
-                        "ticker": "ERC20"
+                        "type": "fiat",
+                        "ticker": "USD"
                     },
                     {
                         "type": "fiat",
-                        "ticker": "USD"
+                        "ticker": "EUR"
+                    },
+                    {
+                        "type": "fiat",
+                        "ticker": "CAD"
+                    },
+                    {
+                        "type": "fiat",
+                        "ticker": "CNY"
+                    },
+                    {
+                        "type": "fiat",
+                        "ticker": "VEF"
                     }
                 ],
                 "wallet_types": [
@@ -113,7 +129,7 @@
                 "fio": "Y",
                 "form_factor": "mobile",
                 "custom_node": "N",
-                "rbf": "Y",
+                "rbf": "N",
                 "psbt": "N",
                 "reproducible_builds": "Y",
                 "hd": "Y",

--- a/matrix.json
+++ b/matrix.json
@@ -20,7 +20,7 @@
     },
     "wallets": [
         {
-            "name": "MyCelium",
+            "name": "Mycelium",
             "web": "https://wallet.mycelium.com/",
             "uuid": "67B71901-D5BF-4F15-A623-AD5A5A93CC9B",
             "features": {
@@ -32,6 +32,14 @@
                     {
                         "type": "crypto",
                         "ticker": "BCH"
+                    },
+                    {
+                        "type": "crypto",
+                        "ticker": "ETH"
+                    },
+                    {
+                        "type": "crypto",
+                        "ticker": "ERC20"
                     },
                     {
                         "type": "fiat",
@@ -46,9 +54,6 @@
                 "security": [
                     "pin-on-wallet",
                     "scrambled-pin"
-                ],
-                "privacy": [
-                    "tor"
                 ],
                 "languages": [
                     {
@@ -97,28 +102,28 @@
                         "iso6392": "TR"
                     }
                 ],
-                "custodial": "?",
+                "custodial": "N",
                 "license": [
                     "Apache 2.0",
                     "MS-RL"
                 ],
-                "multisig": "?",
+                "multisig": "N",
                 "testnet": "N",
                 "batchtx": "N",
                 "fio": "Y",
                 "form_factor": "mobile",
                 "custom_node": "N",
                 "rbf": "Y",
-                "psbt": "?",
-                "reproducible_builds": "?",
+                "psbt": "N",
+                "reproducible_builds": "Y",
                 "hd": "Y",
                 "sna": "Y",
-                "fee_estimation": "?",
+                "fee_estimation": "Y",
                 "fee_control": "Y",
                 "hardware": [],
                 "lightning": [],
-                "refill": [],
-                "validation": "spv",
+                "refill": ["credit-card"],
+                "validation": "via-own-servers",
                 "platforms": [
                     {
                         "name": "ios",
@@ -130,11 +135,11 @@
                         "name": "android",
                         "github": "https://github.com/mycelium-com/wallet-android",
                         "download": "https://play.google.com/store/apps/details?id=com.mycelium.wallet",
-                        "language": "Java"
+                        "language": "Kotlin"
                     }
                 ],
-                "coin_control": "?",
-                "tx_labelling": "?"
+                "coin_control": "N",
+                "tx_labelling": "Y"
             }
         }
     ]


### PR DESCRIPTION
The above matrix does **not** apply to Mycelium iPhone. That is a completely different app with different features.

Mycelium Android [does support some +90 shitcoins](https://github.com/mycelium-com/wallet-android/blob/76b47a9bb8ba77bf3e07264e0396bb73f4cab5e0/mbw/src/main/java/com/mycelium/wallet/WalletConfiguration.kt#L317) most of which are ERC20. I now see that "ERC20" is not allowed by your schema but I see ERC20 tokens with 5-long symbols like ABYSS, so maybe the schema needs changing, too.

The organization wasn't founded the date presented here with the name it has now. It changed its name and location a few times.